### PR TITLE
Fix in PEs compute for full graph experiments

### DIFF
--- a/data/SBMs.py
+++ b/data/SBMs.py
@@ -128,6 +128,17 @@ def make_full_graph(g):
     full_g = dgl.from_networkx(nx.complete_graph(g.number_of_nodes()))
     full_g.ndata['feat'] = g.ndata['feat']
     full_g.edata['feat'] = torch.zeros(full_g.number_of_edges())
+    
+    try:
+        full_g.ndata['lap_pos_enc'] = g.ndata['lap_pos_enc']
+    except:
+        pass
+    
+    try:
+        full_g.ndata['wl_pos_enc'] = g.ndata['wl_pos_enc']
+    except:
+        pass 
+    
     return full_g
     
     

--- a/data/molecules.py
+++ b/data/molecules.py
@@ -14,12 +14,6 @@ import numpy as np
 import networkx as nx
 import hashlib
 
-# *NOTE
-# The dataset pickle and index files are in ./zinc_molecules/ dir
-# [<split>.pickle and <split>.index; for split 'train', 'val' and 'test']
-
-
-
 
 class MoleculeDGL(torch.utils.data.Dataset):
     def __init__(self, data_dir, split, num_graphs=None):
@@ -156,6 +150,17 @@ def make_full_graph(g):
     full_g = dgl.from_networkx(nx.complete_graph(g.number_of_nodes()))
     full_g.ndata['feat'] = g.ndata['feat']
     full_g.edata['feat'] = torch.zeros(full_g.number_of_edges()).long()
+    
+    try:
+        full_g.ndata['lap_pos_enc'] = g.ndata['lap_pos_enc']
+    except:
+        pass
+
+    try:
+        full_g.ndata['wl_pos_enc'] = g.ndata['wl_pos_enc']
+    except:
+        pass    
+    
     return full_g
 
 

--- a/main_SBMs_node_classification.py
+++ b/main_SBMs_node_classification.py
@@ -87,11 +87,6 @@ def train_val_pipeline(MODEL_NAME, dataset, params, net_params, dirs):
     
     DATASET_NAME = dataset.name
     
-    if net_params['full_graph']:
-        print("[!] Converting the given graphs to full graphs..")
-        dataset._make_full_graph()
-        print('Time taken to convert to full graphs:',time.time()-start0)
-    
     if net_params['lap_pos_enc']:
         st = time.time()
         print("[!] Adding Laplacian positional encoding.")
@@ -103,6 +98,12 @@ def train_val_pipeline(MODEL_NAME, dataset, params, net_params, dirs):
         print("[!] Adding WL positional encoding.")
         dataset._add_wl_positional_encodings()
         print('Time WL PE:',time.time()-st)
+    
+    if net_params['full_graph']:
+        st = time.time()
+        print("[!] Converting the given graphs to full graphs..")
+        dataset._make_full_graph()
+        print('Time taken to convert to full graphs:',time.time()-st)
         
     trainset, valset, testset = dataset.train, dataset.val, dataset.test
         

--- a/main_molecules_graph_regression.py
+++ b/main_molecules_graph_regression.py
@@ -81,15 +81,11 @@ def view_model_param(MODEL_NAME, net_params):
 """
 
 def train_val_pipeline(MODEL_NAME, dataset, params, net_params, dirs):
+
     t0 = time.time()
     per_epoch_time = []
         
     DATASET_NAME = dataset.name
-    
-    if net_params['full_graph']:
-        print("[!] Converting the given graphs to full graphs..")
-        dataset._make_full_graph()
-        print('Time taken to convert to full graphs:',time.time()-t0)
     
     if net_params['lap_pos_enc']:
         st = time.time()
@@ -102,6 +98,12 @@ def train_val_pipeline(MODEL_NAME, dataset, params, net_params, dirs):
         print("[!] Adding WL positional encoding.")
         dataset._add_wl_positional_encodings()
         print('Time WL PE:',time.time()-st)
+    
+    if net_params['full_graph']:
+        st = time.time()
+        print("[!] Converting the given graphs to full graphs..")
+        dataset._make_full_graph()
+        print('Time taken to convert to full graphs:',time.time()-st)    
         
     trainset, valset, testset = dataset.train, dataset.val, dataset.test
         


### PR DESCRIPTION
This PR corrects the order of computation of positional encodings (PEs) for the full graph attention experiments, shown in the main paper (Table 1, Column 'Full Graph').

Due to the bug, the PEs were computed on the fully connected (fully adjacent) graphs, and not the original sparse graphs. 
With the correction, the PEs are calculated always on the sparse graphs, which is the objective for PEs to capture original graph structure (hence positions as well) and inject them into the nodes.

--

**Ps.** Note that the full graph attention is not what the paper finds best for a graph transformer architecture, and this bug fix does not change the paper's main results, analysis and conclusion. The updated Table 1 will on arxiv's next version of the paper.

Thanks to @Saro00 for pointing this out.